### PR TITLE
Provide clippy and fmt

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,7 @@
             # define Rust toolchain version and targets to be used in this flake
             rust = (pkgs.rust-bin.stable.${rustVersion}.minimal.override
               {
+                extensions = [ "clippy" "rustfmt" ];
                 targets = [ "wasm32-unknown-unknown" ];
               });
 


### PR DESCRIPTION
We do want minimal because we don't need rust-src or rust-analyzer or anything like that. Clippy and fmt should be provided and match the Rust version though!