### PR TITLE
Add aarch64-linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
     flake-parts.lib.mkFlake { inherit inputs; }
       {
         # systems that his flake can be used on
-        systems = [ "aarch64-darwin" "x86_64-linux" "x86_64-darwin" ];
+        systems = [ "aarch64-darwin" "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
 
         # for each system...
         perSystem = { config, pkgs, system, ... }:


### PR DESCRIPTION
Make aarch64 a supported platform. We could try something like run-on-arch to get CI in place for this but for now I think it's okay to wait for GitHub actions to bring ARM support out of private preview. There's not that much demand for it!