### PR TITLE
Advertise cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install nix
         uses: cachix/install-nix-action@v27
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.23.2/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
 
       - uses: cachix/cachix-action@v15
         with:
@@ -99,7 +99,7 @@ jobs:
       - name: Install nix
         uses: cachix/install-nix-action@v27
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.23.2/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
 
       - uses: cachix/cachix-action@v15
         with:
@@ -134,11 +134,7 @@ jobs:
 
       - uses: cachix/install-nix-action@v27
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.23.2/install
-
-      - uses: cachix/cachix-action@v15
-        with:
-          name: holochain-ci
+          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
 
       - name: Extract branch name
         id: extract_branch

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,5 +145,5 @@ jobs:
         run: |
           cd $(mktemp -d)
           echo "Fetching template from branch ${{ steps.extract_branch.outputs.branch }}"
-          nix flake init -t "github:holochain/holonix?ref=${{ steps.extract_branch.outputs.branch }}#${{ matrix.template }}"
+          nix flake init --accept-flake-config -t "github:holochain/holonix?ref=${{ steps.extract_branch.outputs.branch }}#${{ matrix.template }}"
           nix develop --override-input holonix "github:holochain/holonix?ref=${{ steps.extract_branch.outputs.branch }}" -c hn-introspect

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,8 @@ jobs:
         uses: cachix/install-nix-action@v27
         with:
           install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          extra_nix_config: |
+            accept-flake-config = true
 
       - uses: cachix/cachix-action@v15
         with:
@@ -100,6 +102,8 @@ jobs:
         uses: cachix/install-nix-action@v27
         with:
           install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          extra_nix_config: |
+            accept-flake-config = true
 
       - uses: cachix/cachix-action@v15
         with:
@@ -135,6 +139,8 @@ jobs:
       - uses: cachix/install-nix-action@v27
         with:
           install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          extra_nix_config: |
+            accept-flake-config = true
 
       - name: Extract branch name
         id: extract_branch
@@ -145,5 +151,5 @@ jobs:
         run: |
           cd $(mktemp -d)
           echo "Fetching template from branch ${{ steps.extract_branch.outputs.branch }}"
-          nix flake init --accept-flake-config -t "github:holochain/holonix?ref=${{ steps.extract_branch.outputs.branch }}#${{ matrix.template }}"
+          nix flake init -t "github:holochain/holonix?ref=${{ steps.extract_branch.outputs.branch }}#${{ matrix.template }}"
           nix develop --override-input holonix "github:holochain/holonix?ref=${{ steps.extract_branch.outputs.branch }}" -c hn-introspect

--- a/.github/workflows/command-listener.yaml
+++ b/.github/workflows/command-listener.yaml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v27
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.23.2/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
       - name: set up git config
         run: |
           ./scripts/ci-git-config.sh
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v27
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.23.2/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
       - name: set up git config
         run: |
           ./scripts/ci-git-config.sh
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v27
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.23.2/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
       - name: set up git config
         run: |
           ./scripts/ci-git-config.sh

--- a/.github/workflows/command-listener.yaml
+++ b/.github/workflows/command-listener.yaml
@@ -49,6 +49,8 @@ jobs:
       - uses: cachix/install-nix-action@v27
         with:
           install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          extra_nix_config: |
+            accept-flake-config = true
       - name: set up git config
         run: |
           ./scripts/ci-git-config.sh
@@ -73,6 +75,8 @@ jobs:
       - uses: cachix/install-nix-action@v27
         with:
           install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          extra_nix_config: |
+            accept-flake-config = true
       - name: set up git config
         run: |
           ./scripts/ci-git-config.sh
@@ -97,6 +101,8 @@ jobs:
       - uses: cachix/install-nix-action@v27
         with:
           install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          extra_nix_config: |
+            accept-flake-config = true
       - name: set up git config
         run: |
           ./scripts/ci-git-config.sh

--- a/.github/workflows/holonix-cache.yaml
+++ b/.github/workflows/holonix-cache.yaml
@@ -44,6 +44,8 @@ jobs:
       - uses: cachix/install-nix-action@v27
         with:
           install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          extra_nix_config: |
+            accept-flake-config = true
       - uses: cachix/cachix-action@v15
         with:
           name: holochain-ci
@@ -104,6 +106,8 @@ jobs:
       - uses: cachix/install-nix-action@v27
         with:
           install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          extra_nix_config: |
+            accept-flake-config = true
       - uses: cachix/cachix-action@v15
         with:
           name: holochain-ci

--- a/.github/workflows/holonix-cache.yaml
+++ b/.github/workflows/holonix-cache.yaml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: cachix/install-nix-action@v27
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.23.2/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
       - uses: cachix/cachix-action@v15
         with:
           name: holochain-ci
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: cachix/install-nix-action@v27
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.23.2/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
       - uses: cachix/cachix-action@v15
         with:
           name: holochain-ci

--- a/.github/workflows/holonix-update.yaml
+++ b/.github/workflows/holonix-update.yaml
@@ -57,7 +57,7 @@ jobs:
           ref: ${{ inputs.branch }}
       - uses: cachix/install-nix-action@v27
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.23.2/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
       - name: Run the Holochain bump script
         if: ${{ inputs.update-holochain }}
         run: |

--- a/.github/workflows/holonix-update.yaml
+++ b/.github/workflows/holonix-update.yaml
@@ -58,6 +58,8 @@ jobs:
       - uses: cachix/install-nix-action@v27
         with:
           install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          extra_nix_config: |
+            accept-flake-config = true
       - name: Run the Holochain bump script
         if: ${{ inputs.update-holochain }}
         run: |

--- a/flake.lock
+++ b/flake.lock
@@ -1,17 +1,12 @@
 {
   "nodes": {
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1724537630,
-        "narHash": "sha256-gpqINM71zp3kw5XYwUXa84ZtPnCmLLnByuFoYesT1bY=",
+        "lastModified": 1725125250,
+        "narHash": "sha256-CB20rDD5eHikF6mMTTJdwPP1qvyoiyyw1RDUzwIaIF8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "3e08f4b1fc9aaede5dd511d8f5f4ef27501e49b0",
+        "rev": "96fd12c7100e9e05fa1a0a5bd108525600ce282f",
         "type": "github"
       },
       "original": {
@@ -25,11 +20,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1725234343,
+        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
         "type": "github"
       },
       "original": {
@@ -124,14 +119,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1722555339,
-        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       }
     },
     "root": {
@@ -153,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724898214,
-        "narHash": "sha256-4yMO9+Lsr3zqTf4clAGGag/bfNTmc/ITOXbJQcOEok4=",
+        "lastModified": 1725243956,
+        "narHash": "sha256-0A5ZP8uDCyBdYUzayZfy6JFdTefP79oZVAjyqA/yuSI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0bc2c784e3a6ce30a2ab1b9f47325ccbed13039f",
+        "rev": "a10c8092d5f82622be79ed4dd12289f72011f850",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -362,8 +362,8 @@
       };
     };
 
-    nixConfig = {
-      substituters = [ "https://holochain-ci.cachix.org" ];
-      trusted-public-keys = [ "holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8=" ];
-    };
+  nixConfig = {
+    substituters = [ "https://cache.nixos.org" "https://holochain-ci.cachix.org" ];
+    trusted-public-keys = [ "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" "holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8=" ];
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,6 @@
     # lib to build a nix package from a rust crate
     crane = {
       url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     # Rust toolchain
@@ -361,5 +360,10 @@
           description = "Holonix template for Holo-enabled app development";
         };
       };
+    };
+
+    nixConfig = {
+      substituters = [ "https://holochain-ci.cachix.org" ];
+      trusted-public-keys = [ "holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8=" ];
     };
 }


### PR DESCRIPTION
See https://nixos.wiki/wiki/flakes

> nixConfig is an attribute set of values which reflect the [values given to nix.conf](https://nixos.org/manual/nix/stable/command-ref/conf-file.html). This can extend the normal behavior of a user's nix experience by adding flake-specific configuration, such as a binary cache.

When using this flake, you will now see something like:

```text
do you want to allow configuration setting 'substituters' to be set to 'https://holochain-ci.cachix.org' (y/N)? y
do you want to permanently mark this value as trusted (y/N)? y
do you want to allow configuration setting 'trusted-public-keys' to be set to 'holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8=' (y/N)? y
do you want to permanently mark this value as trusted (y/N)? y
```

I'm not sure yet whether this extends to flakes that consume this one, but it should mean we can do away with the custom install script at some point. Just let Nix do the environment setup and let people install Nix however they'd like. Maybe it should stay as a convenience thing but certainly won't be absolutely necessary :) 

The only downside with this, and I personally don't think that it's major, is that you need to be a trusted user.

```shell
echo "trusted-users = root thetasinner" >> /etc/nix/nix.conf
systemctl restart nix-daemon
```

and you're good to go. Otherwise you get warnings about you not being a trusted user so the cache is being ignored.

The alternative was that we forced the settings into the root config globally. I'm not sure that was better really.