### PR TITLE
fix hc-scaffold cranelib filters

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -248,8 +248,7 @@
                 craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
                 crateInfo = craneLib.crateNameFromCargoToml { cargoToml = ./Cargo.toml; };
 
-                # source filtering to ensure builds using include_str! or include_bytes! succeed
-                # https://crane.dev/faq/building-with-non-rust-includes.html
+                # Crane filters out all non-cargo related files. Define include filter with files needed for build
                 excludedDirs = [
                   ".git"
                   "target"

--- a/flake.nix
+++ b/flake.nix
@@ -240,17 +240,11 @@
 
             hc-scaffold =
               let
-                pkgs = import nixpkgs {
-                  inherit system;
-                  overlays = [ (import rust-overlay) ];
-                };
-
                 # Crane filters out all non-cargo related files. Define include filter with files needed for build
                 excludedDirs = [
                   ".git"
                   "target"
                   "result"
-                  # Add more directories to exclude here
                 ];
                 scaffoldFilter = path: type:
                   let

--- a/flake.nix
+++ b/flake.nix
@@ -244,9 +244,6 @@
                   inherit system;
                   overlays = [ (import rust-overlay) ];
                 };
-                rustToolchain = pkgs.rust-bin.stable."1.79.0".minimal;
-                craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
-                crateInfo = craneLib.crateNameFromCargoToml { cargoToml = ./Cargo.toml; };
 
                 # Crane filters out all non-cargo related files. Define include filter with files needed for build
                 excludedDirs = [


### PR DESCRIPTION
This PR addresses an issue where UI elements for entry/link types and collections were not being scaffolded when using the hc-scaffold nix package from holochain/holonix.

Changes made:
1. Updated source filtering in `cranelib.BuildPackage` to include handlebars templates
2. Ensured that templates for scaffolding entry/link types and collections are properly packaged

This fix resolves the inconsistency between global cargo installation and nix shell usage of the scaffolding CLI, ensuring that all necessary templates are available regardless of the installation method.

---
Should be backported to `main-0.3`