### PR TITLE
Chore/67 fix caching for macos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,9 +25,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v30
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.9/install
           extra_nix_config: |
             accept-flake-config = true
 
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v30
         with:
           install_url: https://releases.nixos.org/nix/nix-2.24.6/install
           extra_nix_config: |
@@ -139,9 +139,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v30
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.9/install
           extra_nix_config: |
             accept-flake-config = true
 

--- a/.github/workflows/command-listener.yaml
+++ b/.github/workflows/command-listener.yaml
@@ -46,9 +46,9 @@ jobs:
     if: ${{ startsWith(needs.action_pr_comment.outputs.action, 'bump holochain') }}
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v30
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.9/install
           extra_nix_config: |
             accept-flake-config = true
       - name: set up git config
@@ -73,9 +73,9 @@ jobs:
     if: ${{ startsWith(needs.action_pr_comment.outputs.action, 'bump hc-launch') }}
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v30
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.9/install
           extra_nix_config: |
             accept-flake-config = true
       - name: set up git config
@@ -99,9 +99,9 @@ jobs:
     if: ${{ startsWith(needs.action_pr_comment.outputs.action, 'bump hc-scaffold') }}
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v30
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.9/install
           extra_nix_config: |
             accept-flake-config = true
       - name: set up git config

--- a/.github/workflows/holonix-cache.yaml
+++ b/.github/workflows/holonix-cache.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           name: holochain-ci
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Maximize build space
+      - name: Maximize build space (Linux)
         if: runner.os == 'Linux'
         uses: AdityaGarg8/remove-unwanted-software@v2
         with:
@@ -58,6 +58,15 @@ jobs:
           remove-android: 'true'
           remove-codeql: 'true'
           remove-docker-images: 'true'
+      - name: Maximise build space (Mac OS)
+        if: runner.os == 'macOS'
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Check disk space before
+        run: df -h /
       - name: Extract branch name
         id: select_branch
         shell: bash

--- a/.github/workflows/holonix-cache.yaml
+++ b/.github/workflows/holonix-cache.yaml
@@ -41,9 +41,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v30
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.9/install
           extra_nix_config: |
             accept-flake-config = true
       - uses: cachix/cachix-action@v15
@@ -103,9 +103,9 @@ jobs:
             platform: x86_64-darwin
     runs-on: ubuntu-latest
     steps:
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v30
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.9/install
           extra_nix_config: |
             accept-flake-config = true
       - uses: cachix/cachix-action@v15

--- a/.github/workflows/holonix-update.yaml
+++ b/.github/workflows/holonix-update.yaml
@@ -55,9 +55,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v30
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.24.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.9/install
           extra_nix_config: |
             accept-flake-config = true
       - name: Run the Holochain and Lair bump scripts


### PR DESCRIPTION
This was a disk space issue. The cache pull was failing around the same point each time so I think it's not actually a network error but a full disk causing operations to be cancelled.

I've also updated the actions versions and the Nix version we use for good measure. 
In future, I think we can avoid needing to manually bump actions versions and have Dependabot do it, trying that out based on these [docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)