### PR TITLE
ci: More build space on macos

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,14 +84,22 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Maximize build space
+      - name: Maximize build space (Linux)
         if: runner.os == 'Linux'
         uses: AdityaGarg8/remove-unwanted-software@v4
         with:
-          remove-dotnet: "true"
-          remove-android: "true"
-          remove-codeql: "true"
-          remove-docker-images: "true"
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+
+      - name: Maximise build space (Mac OS)
+        if: runner.os == 'macOS'
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Print platform information
         run: uname -ms


### PR DESCRIPTION
This is the same fix that was put in for the Cachix update job. We're seeing build failures on PRs for the same reason as we were on the cache jobs. See #76