### PR TITLE
ci: test aarch64-linux build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,7 @@ jobs:
     needs: [nix-check, script-test]
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13]
         packages:
           - [holochain,hc,hc-run-local-services,hc-sandbox,hcterm]
           - [lair-keystore]


### PR DESCRIPTION
Suggestion to test holonix build on `aarch64-linux` too; no caching.