### PR TITLE
build: bump rust to 1.81.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
               inherit system overlays;
             };
 
-            rustVersion = "1.78.0";
+            rustVersion = "1.81.0";
 
             # define Rust toolchain version and targets to be used in this flake
             rust = (pkgs.rust-bin.stable.${rustVersion}.minimal.override


### PR DESCRIPTION
For main-0.3, bump rust to 1.81.0, as some holochain dependencies now require it.