### PR TITLE
chore: Fix webkitgtk warning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -258,7 +258,7 @@
                     [
                       pkgs.glib
                       pkgs.go
-                      pkgs.webkitgtk.dev
+                      pkgs.webkitgtk_4_0.dev
                     ]);
 
                   # do not check built package as it either builds successfully or not


### PR DESCRIPTION
We've been getting a warning for a long time: `evaluation warning: Explicitly set the ABI version of 'webkitgtk'`

This error message wasn't clearly pointing to a solution, but the package has been removed in nixos-unstable and now comes with an error message that we're supposed to pick a version. That's what this PR does and that fixes the warning.