### PR TITLE
fix: add required fetcherVersion to pnpm.fetchDeps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -335,6 +335,7 @@
                   pnpmDeps = pkgs.pnpm_9.fetchDeps {
                     inherit (finalAttrs) pname version src;
                     hash = "sha256-gakSG1K/DkS/7pt5PCdS9ODsUEiv56ZkHBdFcJgmlk4=";
+                    fetcherVersion = 1;
                   };
 
                   buildPhase = ''


### PR DESCRIPTION
Resolves #191. Recent nixpkgs versions require the `fetcherVersion` parameter for `pnpm.fetchDeps`. This change adds the missing parameter to fix build failures.

See similar PR here: https://github.com/darksoil-studio/holochain-playground/pull/15

> [!NOTE]
>
> `fetcherVersion = 1` is what Nix seems to be using in their codebase, for the most part. There's also version `2`, but I can't find any docs on it. 😥