### PR TITLE
fix: add required fetcherVersion to pnpm.fetchDeps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -335,6 +335,7 @@
                   pnpmDeps = pkgs.pnpm_9.fetchDeps {
                     inherit (finalAttrs) pname version src;
                     hash = "sha256-gakSG1K/DkS/7pt5PCdS9ODsUEiv56ZkHBdFcJgmlk4=";
+                    fetcherVersion = 1;
                   };
 
                   buildPhase = ''


### PR DESCRIPTION
Recent nixpkgs versions require the fetcherVersion parameter for pnpm.fetchDeps. This change adds the missing parameter to fix build failures.

This PR is to replace #193, which couldn't run the CI workflows (maybe we should fix that).

Closes #191 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Specify fetcher version for pnpm dependencies to improve build consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->