### PR TITLE
chore: Support go-pion builds of Holochain

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -128,8 +128,14 @@
                   pkgs.perl
                   pkgs.cmake
                   pkgs.clang
+                  pkgs.go
                   pkgs.llvmPackages_18.libunwind
                 ];
+
+                # Avoid Go trying to init modules in a directory that isn't writable while building tx5-go-pion-sys.
+                preBuild = ''
+                  export HOME=$(mktemp -d)
+                '';
 
                 # do not check built package as it either builds successfully or not
                 doCheck = false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved build failures for Go-based components by using a writable temporary HOME during build.

* **Chores**
  * Added Go tooling to the build environment to support Go-dependent parts.
  * Maintained existing build flow (no changes to test execution or other settings).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->