### PR TITLE
chore: Bump to K2 0.3.1 and Holochain 0.6.0-rc.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,7 @@ jobs:
     needs: [nix-check, script-test]
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel]
         packages:
           - [holochain,hc,hcterm]
           - [bootstrap-srv]

--- a/.github/workflows/holonix-cache.yaml
+++ b/.github/workflows/holonix-cache.yaml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, macos-13 ]
+        os: [ ubuntu-latest, macos-latest, macos-15-intel ]
 
     runs-on: ${{ matrix.os }}
 
@@ -104,13 +104,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, macos-13 ]
+        os: [ ubuntu-latest, macos-latest, macos-15-intel ]
         include:
           - os: ubuntu-latest
             platform: x86_64-linux
           - os: macos-latest
             platform: aarch64-darwin
-          - os: macos-13
+          - os: macos-15-intel
             platform: x86_64-darwin
     runs-on: ubuntu-latest
     steps:

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1762189950,
-        "narHash": "sha256-aotggLUXjlDGqKWibGPQcMZJGgdr79S21ISrv1Wz6RI=",
+        "lastModified": 1762538466,
+        "narHash": "sha256-8zrIPl6J+wLm9MH5ksHcW7BUHo7jSNOu0/hA0ohOOaM=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "50700219af884287ad7c85507e2f163b23a027a9",
+        "rev": "0cea393fffb39575c46b7a0318386467272182fe",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1762040540,
-        "narHash": "sha256-z5PlZ47j50VNF3R+IMS9LmzI5fYRGY/Z5O5tol1c9I4=",
+        "lastModified": 1762810396,
+        "narHash": "sha256-dxFVgQPG+R72dkhXTtqUm7KpxElw3u6E+YlQ2WaDgt8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "0010412d62a25d959151790968765a70c436598b",
+        "rev": "0bdadb1b265fb4143a75bd1ec7d8c915898a9923",
         "type": "github"
       },
       "original": {
@@ -70,16 +70,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1762372467,
-        "narHash": "sha256-8LoKyzjkAoHOlJ0+8hUrwc0LTX7/2TdVODoLwMZMNVA=",
+        "lastModified": 1762823444,
+        "narHash": "sha256-MZVvafx1zkfLhuOW9oi/cfOkN+SPGtnIDN8x5Rqif8U=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "90f56b5bf15b572cd9fdbd63d5a40a288143ff5f",
+        "rev": "d2c93682c64c380ea66b90ac6fe87d6fbd8d7eee",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.6.0-rc.0",
+        "ref": "holochain-0.6.0-rc.1",
         "repo": "holochain",
         "type": "github"
       }
@@ -87,16 +87,16 @@
     "kitsune2": {
       "flake": false,
       "locked": {
-        "lastModified": 1762303720,
-        "narHash": "sha256-tC2k+1kPxpVYRYJLWYXQPvFlUwgfF4cKoFKbkak0vxU=",
+        "lastModified": 1762780171,
+        "narHash": "sha256-+rC+/IuHtTlfO2Q69PUNqjw+8sTKcAuySCtxJyKEmrY=",
         "owner": "holochain",
         "repo": "kitsune2",
-        "rev": "112099b30381ea0d23b8b3af21f5b5bb81ced6c5",
+        "rev": "c3152f131ffc00f727c4411a537e9be67d74ecd8",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.3.0",
+        "ref": "v0.3.1",
         "repo": "kitsune2",
         "type": "github"
       }
@@ -120,11 +120,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762233356,
-        "narHash": "sha256-cGS3lLTYusbEP/IJIWGgnkzIl+FA5xDvtiHyjalGr4k=",
+        "lastModified": 1762756533,
+        "narHash": "sha256-HiRDeUOD1VLklHeOmaKDzf+8Hb7vSWPVFcWwaTrpm+U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ca534a76c4afb2bdc07b681dbc11b453bab21af8",
+        "rev": "c2448301fb856e351aab33e64c33a3fc8bcf637d",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762396738,
-        "narHash": "sha256-BarSecuxtzp1boERdABLkkoxQTi6s/V33lJwUbWLrLY=",
+        "lastModified": 1762828736,
+        "narHash": "sha256-RxtFHWZpKwVcWHhx88E2NhWuBbgYVqIoIDynGs5FoJs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c63598992afd54d215d54f2b764adc0484c2b159",
+        "rev": "8d5baa5628f6dbd7ce6beca3c299bae27755204c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,13 +21,13 @@
     };
 
     kitsune2 = {
-      url = "github:holochain/kitsune2?ref=v0.3.0";
+      url = "github:holochain/kitsune2?ref=v0.3.1";
       flake = false;
     };
 
     # Holochain sources
     holochain = {
-      url = "github:holochain/holochain?ref=holochain-0.6.0-rc.0";
+      url = "github:holochain/holochain?ref=holochain-0.6.0-rc.1";
       flake = false;
     };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated kitsune2 and holochain inputs to newer patch releases for improved compatibility.
  * Upgraded CI macOS runner selection from macOS-13 to macOS-15-intel across build and cache workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->