### PR TITLE
Update holochain to 0.6.0 and K2 to 0.3.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1762538466,
-        "narHash": "sha256-8zrIPl6J+wLm9MH5ksHcW7BUHo7jSNOu0/hA0ohOOaM=",
+        "lastModified": 1763511871,
+        "narHash": "sha256-KKZWi+ij7oT0Ag8yC6MQkzfHGcytyjMJDD+47ZV1YNU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "0cea393fffb39575c46b7a0318386467272182fe",
+        "rev": "099f9014bc8d0cd6e445470ea1df0fd691d5a548",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1762810396,
-        "narHash": "sha256-dxFVgQPG+R72dkhXTtqUm7KpxElw3u6E+YlQ2WaDgt8=",
+        "lastModified": 1762980239,
+        "narHash": "sha256-8oNVE8TrD19ulHinjaqONf9QWCKK+w4url56cdStMpM=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "0bdadb1b265fb4143a75bd1ec7d8c915898a9923",
+        "rev": "52a2caecc898d0b46b2b905f058ccc5081f842da",
         "type": "github"
       },
       "original": {
@@ -70,16 +70,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1762823444,
-        "narHash": "sha256-MZVvafx1zkfLhuOW9oi/cfOkN+SPGtnIDN8x5Rqif8U=",
+        "lastModified": 1763554421,
+        "narHash": "sha256-uCVTHeoJpDcc3Ky6gXt1oZX7XxVL3CmY9pFVQ5AEXtM=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "d2c93682c64c380ea66b90ac6fe87d6fbd8d7eee",
+        "rev": "a6d4e805a0971ccbc0dcb3f3ed6a9e2fac980a3b",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.6.0-rc.1",
+        "ref": "holochain-0.6.0",
         "repo": "holochain",
         "type": "github"
       }
@@ -87,16 +87,16 @@
     "kitsune2": {
       "flake": false,
       "locked": {
-        "lastModified": 1762780171,
-        "narHash": "sha256-+rC+/IuHtTlfO2Q69PUNqjw+8sTKcAuySCtxJyKEmrY=",
+        "lastModified": 1763403287,
+        "narHash": "sha256-dqQJMoDbcD0ekttrv5+8ph5Yf25EdXwKktsxNjV57Iw=",
         "owner": "holochain",
         "repo": "kitsune2",
-        "rev": "c3152f131ffc00f727c4411a537e9be67d74ecd8",
+        "rev": "22de6e42100aa960d05f5f30427a236ad922bd80",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.3.1",
+        "ref": "v0.3.2",
         "repo": "kitsune2",
         "type": "github"
       }
@@ -120,11 +120,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762756533,
-        "narHash": "sha256-HiRDeUOD1VLklHeOmaKDzf+8Hb7vSWPVFcWwaTrpm+U=",
+        "lastModified": 1763334038,
+        "narHash": "sha256-LBVOyaH6NFzQ3X/c6vfMZ9k4SV2ofhpxeL9YnhHNJQQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c2448301fb856e351aab33e64c33a3fc8bcf637d",
+        "rev": "4c8cdd5b1a630e8f72c9dd9bf582b1afb3127d2c",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762828736,
-        "narHash": "sha256-RxtFHWZpKwVcWHhx88E2NhWuBbgYVqIoIDynGs5FoJs=",
+        "lastModified": 1763519912,
+        "narHash": "sha256-N2YN0ZNBoz2zRRjmATePp9GbmGSGpVh3+piXn6mtgKc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8d5baa5628f6dbd7ce6beca3c299bae27755204c",
+        "rev": "a9c35d6e7cb70c5719170b6c2d3bb589c5e048af",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,13 +21,13 @@
     };
 
     kitsune2 = {
-      url = "github:holochain/kitsune2?ref=v0.3.1";
+      url = "github:holochain/kitsune2?ref=v0.3.2";
       flake = false;
     };
 
     # Holochain sources
     holochain = {
-      url = "github:holochain/holochain?ref=holochain-0.6.0-rc.1";
+      url = "github:holochain/holochain?ref=holochain-0.6.0";
       flake = false;
     };
 


### PR DESCRIPTION
- Holochain version 0.6.0
- kitsune2 version 0.3.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Holochain to the final 0.6.0 release.
  * Updated kitsune2 to v0.3.2.
  * These are dependency input updates only; no functional, build-output, or user-visible behavior changes are expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->