### PR TITLE
chore: prepare 0.6 branching

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       - main
+      - main-0.6
       - main-0.5
       - main-0.4
       - main-0.3
   pull_request:
     branches:
       - main
+      - main-0.6
       - main-0.5
       - main-0.4
       - main-0.3
@@ -67,7 +69,7 @@ jobs:
 
           # Print tag that would be used to update flake on main branch
           CURRENT_VERSION=$(./scripts/bump-holochain.sh main false | tail -n 1)
-          if [[ "$CURRENT_VERSION" != holochain-0.6.*dev* ]]; then
+          if [[ "$CURRENT_VERSION" != holochain-0.7.*dev* ]]; then
               echo "bump.sh failed to find current version: [${CURRENT_VERSION}]"
               exit 1
           fi

--- a/.github/workflows/command-listener.yaml
+++ b/.github/workflows/command-listener.yaml
@@ -14,11 +14,11 @@ jobs:
         id: dispatch
         env:
           USER: ${{ github.event.sender.login }}
-          ALLOWED_USERS: ${{ join(fromJson('["ThetaSinner", "jost-s", "neonphog", "matthme", "c12i", "cdunster"]'), '\n') }}
+          ALLOWED_USERS: ${{ join(fromJson('["ThetaSinner", "jost-s", "matthme", "cdunster", "mattyg", "veeso"]'), '\n') }}
           COMMENT: ${{ github.event.comment.body }}
         run: |
           set -euo pipefail
-          
+
           COMMAND=""
           if [[ "$COMMENT" == @hra* ]]; then
             echo "Comment is a command"
@@ -27,7 +27,7 @@ jobs:
             echo "Comment is not a command"
             exit 0
           fi
-          
+
           if echo "$ALLOWED_USERS" | grep -q "${USER}"; then
             echo "User $USER is allowed to run commands"
           else
@@ -35,7 +35,7 @@ jobs:
             exit 1
           fi
 
-          echo "Setting command '$COMMAND'"  
+          echo "Setting command '$COMMAND'"
           echo "action=${COMMAND}" >> "$GITHUB_OUTPUT"
     outputs:
       action: ${{ steps.dispatch.outputs.action }}

--- a/.github/workflows/dispatch-listener.yaml
+++ b/.github/workflows/dispatch-listener.yaml
@@ -5,10 +5,16 @@ on:
 
 jobs:
   bump_holochain-main:
-    if: ${{ github.event.action == 'holochain-released' && startsWith(github.event.client_payload.tag, 'holochain-0.6') }}
+    if: ${{ github.event.action == 'holochain-released' && startsWith(github.event.client_payload.tag, 'holochain-0.7') }}
     uses: holochain/holonix/.github/workflows/holonix-update.yaml@main
     with:
       branch: main
+      update-holochain: true
+  bump_holochain-main-0_6:
+    if: ${{ github.event.action == 'holochain-released' && startsWith(github.event.client_payload.tag, 'holochain-0.6') }}
+    uses: holochain/holonix/.github/workflows/holonix-update.yaml@main
+    with:
+      branch: main-0.6
       update-holochain: true
   bump_holochain-main-0_5:
     if: ${{ github.event.action == 'holochain-released' && startsWith(github.event.client_payload.tag, 'holochain-0.5') }}

--- a/.github/workflows/holonix-cache-trigger.yaml
+++ b/.github/workflows/holonix-cache-trigger.yaml
@@ -15,6 +15,10 @@ jobs:
     uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main
     with:
       branch: main
+  update-cache-main-0_6:
+    uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main
+    with:
+      branch: main-0.6
   update-cache-main-0_5:
     uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main
     with:

--- a/.github/workflows/holonix-cache.yaml
+++ b/.github/workflows/holonix-cache.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - main-0.6
       - main-0.5
       - main-0.4
       - main-0.3
@@ -24,6 +25,7 @@ on:
         type: choice
         options:
           - main
+          - main-0.6
           - main-0.5
           - main-0.4
           - main-0.3
@@ -75,11 +77,11 @@ jobs:
         run: |
           # Figure out what branch was used to trigger the workflow (i.e. the `push` trigger)
           changed_branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          
+
           # Get the input branch override if it exists. This will be set if the workflow is triggered manually or by a
           # workflow call.
           input_branch='${{ inputs.branch }}'
-          
+
           # Pick a branch to work with, preferring the input branch if it exists.
           echo "branch=${input_branch:-$changed_branch}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/holonix-update.yaml
+++ b/.github/workflows/holonix-update.yaml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - main
+          - main-0.6
           - main-0.5
           - main-0.4
           - main-0.3
@@ -83,12 +84,12 @@ jobs:
           title: "Update Holonix versions on ${{ inputs.branch }}"
           body: |
             Automated Holochain version bump.
-            
+
             To apply more updates to this PR you can ask the bot to make changes. Try commenting with:
               - `@hra bump holochain`
               - `@hra bump hc-launch`
               - `@hra bump hc-scaffold`
-            
+
             You must be in the list of allowed users for this to work!
           branch: holochain-update
           branch-suffix: short-commit-hash

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Holonix cache trigger](https://github.com/holochain/holonix/actions/workflows/holonix-cache-trigger.yaml/badge.svg)](https://github.com/holochain/holonix/actions/workflows/holonix-cache-trigger.yaml)
 
 `main` [![Holonix cache](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml/badge.svg)](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml)
+`main-0.6` [![Holonix cache](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml/badge.svg?branch=main-0.6)](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml)
 `main-0.5` [![Holonix cache](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml/badge.svg?branch=main-0.5)](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml)
 `main-0.4` [![Holonix cache](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml/badge.svg?branch=main-0.4)](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml)
 `main-0.3` [![Holonix cache](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml/badge.svg?branch=main-0.3)](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml)

--- a/scripts/bump-holochain.sh
+++ b/scripts/bump-holochain.sh
@@ -29,7 +29,7 @@ CURRENT_BRANCH=${1:-$(git branch --show-current)}
 SEARCH_PATTERN="no-tag"
 case $CURRENT_BRANCH in
     main)
-        SEARCH_PATTERN="^holochain-0.6.[0-9]+-dev.[0-9]+$"
+        SEARCH_PATTERN="^holochain-0.7.[0-9]+-dev.[0-9]+$"
         ;;
     main-*-rc)
         VERSION_STR=$(echo "$CURRENT_BRANCH" | awk -F '-' '{print $2}')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD extended to explicitly support the legacy 0.6 release line alongside the main line, including cache and update workflows.
  * Version checks and bump logic updated to reflect the new development cycle.
  * Expanded allowed runners/operators for dispatch commands.

* **Documentation**
  * Added a cache status badge for the legacy 0.6 line to the README.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->