### PR TITLE
chore: remove holochain 0.3 series

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,14 +7,12 @@ on:
       - main-0.6
       - main-0.5
       - main-0.4
-      - main-0.3
   pull_request:
     branches:
       - main
       - main-0.6
       - main-0.5
       - main-0.4
-      - main-0.3
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/dispatch-listener.yaml
+++ b/.github/workflows/dispatch-listener.yaml
@@ -28,9 +28,3 @@ jobs:
     with:
       branch: main-0.4
       update-holochain: true
-  bump_holochain-0_3:
-    if: ${{ github.event.action == 'holochain-released' && startsWith(github.event.client_payload.tag, 'holochain-0.3') }}
-    uses: holochain/holonix/.github/workflows/holonix-update.yaml@main
-    with:
-      branch: main-0.3
-      update-holochain: true

--- a/.github/workflows/holonix-cache-trigger.yaml
+++ b/.github/workflows/holonix-cache-trigger.yaml
@@ -27,7 +27,3 @@ jobs:
     uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main
     with:
       branch: main-0.4
-  update-cache-main-0_3:
-    uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main
-    with:
-      branch: main-0.3

--- a/.github/workflows/holonix-cache.yaml
+++ b/.github/workflows/holonix-cache.yaml
@@ -9,7 +9,6 @@ on:
       - main-0.6
       - main-0.5
       - main-0.4
-      - main-0.3
   workflow_call:
     inputs:
       branch:
@@ -28,7 +27,6 @@ on:
           - main-0.6
           - main-0.5
           - main-0.4
-          - main-0.3
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.branch }}-${{ github.ref_name }}

--- a/.github/workflows/holonix-update.yaml
+++ b/.github/workflows/holonix-update.yaml
@@ -13,7 +13,6 @@ on:
           - main-0.6
           - main-0.5
           - main-0.4
-          - main-0.3
       update-holochain:
         description: "Should Holochain be updated?"
         type: boolean

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 `main-0.6` [![Holonix cache](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml/badge.svg?branch=main-0.6)](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml)
 `main-0.5` [![Holonix cache](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml/badge.svg?branch=main-0.5)](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml)
 `main-0.4` [![Holonix cache](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml/badge.svg?branch=main-0.4)](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml)
-`main-0.3` [![Holonix cache](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml/badge.svg?branch=main-0.3)](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml)
 
 # Holonix
 
@@ -65,25 +64,25 @@ The next time you enter the dev shell, the updated binaries will be downloaded a
 
 ## Including other versions of Holochain
 
-By default the Holonix input references the `main` branch of the Holonix repository. Whatever the current revision of that branch at the moment of invoking the dev shell for the first time is will be written to the `flake.lock` file. The `main` branch uses version 0.5 of Holochain and compatible versions of scaffolding etc.
+By default the Holonix input references the `main` branch of the Holonix repository. Whatever the current revision of that branch at the moment of invoking the dev shell for the first time is will be written to the `flake.lock` file. At the time of writing, the `main` branch uses version 0.6 of Holochain and compatible versions of scaffolding etc.
 
-If you want to develop using the 0.3 (recommended) or 0.4 (RC) release series of Holochain instead, you can create the corresponding Nix flake by running this command inside your project folder, replacing `<ver>` with the correct version number:
+If you want to develop using another series of Holochain instead, you can create the corresponding Nix flake by running this command inside your project folder, replacing `<ver>` with the desired version number:
 
 ```shell
 nix flake init -t github:holochain/holonix?ref=main-<ver>
 ```
 
-Alternatively you can modify an existing `flake.nix` file, changing the `holonix` url in the inputs section to point to `main-0.3`.
+Alternatively you can modify an existing `flake.nix` file, changing the `holonix` url in the inputs section to point to `main-<ver>`, for example:
 
 ```diff
 inputs = {
 -   holonix.url = "github:holochain/holonix?ref=main";
-+   holonix.url = "github:holochain/holonix?ref=main-0.3";
++   holonix.url = "github:holochain/holonix?ref=main-0.5";
     ...
 };
 ```
 
-Running `nix develop` now will update the flake lock file with the current revision of the `main-0.3` branch of the Holonix repository and enter the dev shell.
+Running `nix develop` now will update the flake lock file with the current revision of the `main-0.5` branch of the Holonix repository and enter the dev shell.
 
 ### Overriding Holochain version
 


### PR DESCRIPTION
Removes jobs and references to `main-0.3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed Holochain 0.3 support across CI/CD workflows, build triggers, and cache/update jobs, consolidating support to 0.4 and newer.

* **Documentation**
  * Updated README: removed the 0.3 badge and examples, refreshed guidance to be version-agnostic, and replaced explicit 0.3 references with generic/main newer-version examples and override instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->