### PR TITLE
Chore: Final bump to scaffolding 0.600.1, remove hc-launch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,7 +83,6 @@ jobs:
           - [holochain,hc,hcterm]
           - [bootstrap-srv]
           - [lair-keystore]
-          - [hc-launch]
           - [hc-scaffold]
       fail-fast: false
 

--- a/.github/workflows/command-listener.yaml
+++ b/.github/workflows/command-listener.yaml
@@ -66,32 +66,6 @@ jobs:
           git commit -m "chore: Bump Holochain version"
           git pull --rebase
           git push
-  bump_hc_launch:
-    name: Bump hc-launch
-    runs-on: ubuntu-latest
-    needs: [action_pr_comment]
-    if: ${{ startsWith(needs.action_pr_comment.outputs.action, 'bump hc-launch') }}
-    steps:
-      - uses: actions/checkout@v5
-      - uses: cachix/install-nix-action@v31
-        with:
-          install_url: https://releases.nixos.org/nix/nix-2.28.3/install
-          extra_nix_config: |
-            accept-flake-config = true
-      - name: set up git config
-        run: |
-          ./scripts/ci-git-config.sh
-      - name: Flake update
-        env:
-          PR_NUMBER: ${{ github.event.issue.number }}
-          GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
-        run: |
-          gh pr checkout $PR_NUMBER --repo holochain/holonix
-          nix flake update hc-launch
-          git add flake.lock
-          git commit -m "chore: Bump hc-launch version"
-          git pull --rebase
-          git push
   bump_hc_scaffold:
     name: Bump hc-scaffold
     runs-on: ubuntu-latest

--- a/.github/workflows/holonix-update.yaml
+++ b/.github/workflows/holonix-update.yaml
@@ -24,11 +24,6 @@ on:
         type: boolean
         default: false
         required: true
-      update-launcher:
-        description: "Should Launcher be updated?"
-        type: boolean
-        default: false
-        required: true
   workflow_call:
     inputs:
       branch:
@@ -39,10 +34,6 @@ on:
         default: false
         required: false
       update-scaffolding:
-        type: boolean
-        default: false
-        required: false
-      update-launcher:
         type: boolean
         default: false
         required: false

--- a/.github/workflows/holonix-update.yaml
+++ b/.github/workflows/holonix-update.yaml
@@ -71,10 +71,6 @@ jobs:
         if: ${{ inputs.update-scaffolding }}
         run: |
           nix flake update hc-scaffold
-      - name: Run the Launcher bump script
-        if: ${{ inputs.update-launcher }}
-        run: |
-          nix flake update hc-launch
       - name: Create pull request
         id: cpr
         uses: peter-evans/create-pull-request@v7
@@ -87,7 +83,6 @@ jobs:
 
             To apply more updates to this PR you can ask the bot to make changes. Try commenting with:
               - `@hra bump holochain`
-              - `@hra bump hc-launch`
               - `@hra bump hc-scaffold`
 
             You must be in the list of allowed users for this to work!

--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ It may be that you want to add or remove packages included in the dev shell. If 
 packages = (with inputs'.holonix.packages; [
     holochain
 -   lair-keystore
--   hc-launch
 -   hc-scaffold
 -   hn-introspect
     rust # For Rust development, with the WASM target included for zome builds

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1763511871,
-        "narHash": "sha256-KKZWi+ij7oT0Ag8yC6MQkzfHGcytyjMJDD+47ZV1YNU=",
+        "lastModified": 1763938834,
+        "narHash": "sha256-j8iB0Yr4zAvQLueCZ5abxfk6fnG/SJ5JnGUziETjwfg=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "099f9014bc8d0cd6e445470ea1df0fd691d5a548",
+        "rev": "d9e753122e51cee64eb8d2dddfe11148f339f5a2",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1762980239,
-        "narHash": "sha256-8oNVE8TrD19ulHinjaqONf9QWCKK+w4url56cdStMpM=",
+        "lastModified": 1763759067,
+        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "52a2caecc898d0b46b2b905f058ccc5081f842da",
+        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763622513,
-        "narHash": "sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB+19M=",
+        "lastModified": 1763948260,
+        "narHash": "sha256-dY9qLD0H0zOUgU3vWacPY6Qc421BeQAfm8kBuBtPVE0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c58bc7f5459328e4afac201c5c4feb7c818d604b",
+        "rev": "1c8ba8d3f7634acac4a2094eef7c32ad9106532c",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763692705,
-        "narHash": "sha256-tCKCyMYU0Vy+ph/xswlNsYXXjnFVweWBV+ew/5FS9tA=",
+        "lastModified": 1764297505,
+        "narHash": "sha256-qrLpVu2/hA9Cu6IovMEsgh9YRyvmmWS+bSx7C1JGChA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6fbf5d328dce1828d887b8ee7d44a785196a34e7",
+        "rev": "9623580f8ce09ec444b9aca107566ec5db110e62",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -36,16 +36,16 @@
     "hc-scaffold": {
       "flake": false,
       "locked": {
-        "lastModified": 1764024212,
-        "narHash": "sha256-R1WDGUmpMvPF2edwpb6L+NYOFSiH1+U6l7x0Ph2u7l4=",
+        "lastModified": 1764163563,
+        "narHash": "sha256-KigJ3h25yNJfeQunPm5QYFPtLSk6nU3IEEvZY8w01Vo=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "6606aa5520caa85e7696fa5f483b29331890853e",
+        "rev": "87e997a7361d4aa7c1bb96261483ebba50223bd0",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.600.0",
+        "ref": "v0.600.1",
         "repo": "scaffolding",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
     "hc-scaffold": {
       "flake": false,
       "locked": {
-        "lastModified": 1764011819,
-        "narHash": "sha256-dGFCjYlgvGiQQx0ubpYh2hf39+YjIirekeo/ZABe21Q=",
+        "lastModified": 1764024212,
+        "narHash": "sha256-R1WDGUmpMvPF2edwpb6L+NYOFSiH1+U6l7x0Ph2u7l4=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "2d71d47b9a2fec079671f3f385e01c238dee7f7e",
+        "rev": "6606aa5520caa85e7696fa5f483b29331890853e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -33,23 +33,6 @@
         "type": "github"
       }
     },
-    "hc-launch": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1764005928,
-        "narHash": "sha256-M1KiSMltyhLMsIageC3rCeVHnlzQU/8lwdGTNpf8Yhk=",
-        "owner": "holochain",
-        "repo": "hc-launch",
-        "rev": "b19fe6be4edff94043b7936496f5604bf7917e97",
-        "type": "github"
-      },
-      "original": {
-        "owner": "holochain",
-        "ref": "holochain-0.6",
-        "repo": "hc-launch",
-        "type": "github"
-      }
-    },
     "hc-scaffold": {
       "flake": false,
       "locked": {
@@ -170,7 +153,6 @@
       "inputs": {
         "crane": "crane",
         "flake-parts": "flake-parts",
-        "hc-launch": "hc-launch",
         "hc-scaffold": "hc-scaffold",
         "holochain": "holochain",
         "kitsune2": "kitsune2",

--- a/flake.nix
+++ b/flake.nix
@@ -37,12 +37,6 @@
       flake = false;
     };
 
-    # Holochain Launch CLI
-    hc-launch = {
-      url = "github:holochain/hc-launch?ref=holochain-0.6";
-      flake = false;
-    };
-
     # Holochain scaffolding CLI
     hc-scaffold = {
       url = "github:holochain/scaffolding?ref=v0.600.0";

--- a/flake.nix
+++ b/flake.nix
@@ -221,61 +221,6 @@
                 doCheck = false;
               };
 
-            # define how to build hc-launch binary
-            hc-launch =
-              let
-                # Crane filters out all non-cargo related files. Define include filter with files needed for build.
-                nonCargoBuildFiles = path: _type: builtins.match ".*(js|json|png)$" path != null;
-                includeFilesFilter = path: type:
-                  (craneLib.filterCargoSources path type) || (nonCargoBuildFiles path type);
-
-                # Crane doesn't know which version to select from a workspace, so we tell it where to look
-                crateInfo = craneLib.crateNameFromCargoToml { cargoToml = inputs.hc-launch + "/crates/hc_launch/src-tauri/Cargo.toml"; };
-
-                commonArgs = {
-                  pname = "hc-launch";
-                  version = crateInfo.version;
-                  # Use hc-launch sources as defined in input dependencies and include only those files defined in the
-                  # filter previously.
-                  src = pkgs.lib.cleanSourceWith {
-                    src = inputs.hc-launch;
-                    filter = includeFilesFilter;
-                  };
-                  # Only build hc-launch command
-                  cargoExtraArgs = "--bin hc-launch";
-
-                  # commands required at build time
-                  nativeBuildInputs = (
-                    if pkgs.stdenv.isLinux then [ pkgs.pkg-config ]
-                    else [ ]
-                  );
-
-                  # build inputs required for linking to execute at runtime
-                  buildInputs = [
-                    pkgs.perl
-                  ]
-                  ++ (pkgs.lib.optionals pkgs.stdenv.isLinux
-                    [
-                      pkgs.glib
-                      pkgs.go
-                      pkgs.webkitgtk_4_0.dev
-                    ]);
-
-                  # do not check built package as it either builds successfully or not
-                  doCheck = false;
-                };
-
-                # derivation building all dependencies
-                deps = craneLib.buildDepsOnly commonArgs;
-              in
-              # derivation with the main crates
-              craneLib.buildPackage
-                (commonArgs // {
-                  cargoArtifacts = deps;
-
-                  stdenv = p: p.stdenv;
-                });
-
             hc-scaffold =
               let
                 # Crane filters out all non-cargo related files. Define include filter with files needed for build.
@@ -364,12 +309,6 @@
                 echo "hc-scaffold            : not installed"
               fi
 
-              if command -v "hc-launch" > /dev/null; then
-                echo "hc-launch              : $(hc-launch --version) (${builtins.substring 0 7 inputs.hc-launch.rev})"
-              else
-                echo "hc-launch              : not installed"
-              fi
-
               if command -v "lair-keystore" > /dev/null; then
                 echo "Lair keystore          : $(lair-keystore --version) (${builtins.substring 0 7 inputs.lair-keystore.rev})"
               else
@@ -414,7 +353,6 @@
               inherit hcterm;
               inherit bootstrap-srv;
               inherit lair-keystore;
-              inherit hc-launch;
               inherit hc-scaffold;
               inherit rust;
               inherit hn-introspect;
@@ -435,8 +373,6 @@
               kitsune2-bootstrap-srv.meta.description = "Kitsune2 bootstrap server";
               lair-keystore.program = "${lair-keystore}/bin/lair-keystore";
               lair-keystore.meta.description = "Lair keystore";
-              hc-launch.program = "${hc-launch}/bin/hc-launch";
-              hc-launch.meta.description = "Holochain launcher CLI";
               hc-scaffold.program = "${hc-scaffold}/bin/hc-scaffold";
               hc-scaffold.meta.description = "Holochain scaffolding CLI";
               hc-playground.program = "${hc-playground}/bin/hc-playground";
@@ -451,7 +387,6 @@
                   hcterm
                   bootstrap-srv
                   lair-keystore
-                  hc-launch
                   hc-scaffold
                   hn-introspect
                   hc-playground

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
 
     # Holochain scaffolding CLI
     hc-scaffold = {
-      url = "github:holochain/scaffolding?ref=v0.600.0";
+      url = "github:holochain/scaffolding?ref=v0.600.1";
       flake = false;
     };
 

--- a/templates/custom-holochain/flake.nix
+++ b/templates/custom-holochain/flake.nix
@@ -37,7 +37,6 @@
             hcterm
             bootstrap-srv
             lair-keystore
-            hc-launch
             hc-scaffold
             hn-introspect
             hc-playground

--- a/templates/custom-rust/flake.nix
+++ b/templates/custom-rust/flake.nix
@@ -41,7 +41,6 @@
             hcterm
             bootstrap-srv
             lair-keystore
-            hc-launch
             hc-scaffold
             hn-introspect
             hc-playground

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -20,7 +20,6 @@
           hcterm
           bootstrap-srv
           lair-keystore
-          hc-launch
           hc-scaffold
           hn-introspect
           hc-playground


### PR DESCRIPTION
This gets `flake.lock` to the commit of scaffolding ~~0.600.0~~ v0.600.1 that scaffolds a nix flake that uses all the most up-to-date tools. It also removes the deprecated `hc-launch` command.