### PR TITLE
Chore: remove deprecated `hc-launch`, bump `hc-scaffold` to 0.600.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,7 +81,6 @@ jobs:
           - [holochain,hc,hcterm]
           - [bootstrap-srv]
           - [lair-keystore]
-          - [hc-launch]
           - [hc-scaffold]
       fail-fast: false
 

--- a/.github/workflows/command-listener.yaml
+++ b/.github/workflows/command-listener.yaml
@@ -66,32 +66,6 @@ jobs:
           git commit -m "chore: Bump Holochain version"
           git pull --rebase
           git push
-  bump_hc_launch:
-    name: Bump hc-launch
-    runs-on: ubuntu-latest
-    needs: [action_pr_comment]
-    if: ${{ startsWith(needs.action_pr_comment.outputs.action, 'bump hc-launch') }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-        with:
-          install_url: https://releases.nixos.org/nix/nix-2.28.3/install
-          extra_nix_config: |
-            accept-flake-config = true
-      - name: set up git config
-        run: |
-          ./scripts/ci-git-config.sh
-      - name: Flake update
-        env:
-          PR_NUMBER: ${{ github.event.issue.number }}
-          GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
-        run: |
-          gh pr checkout $PR_NUMBER --repo holochain/holonix
-          nix flake update hc-launch
-          git add flake.lock
-          git commit -m "chore: Bump hc-launch version"
-          git pull --rebase
-          git push
   bump_hc_scaffold:
     name: Bump hc-scaffold
     runs-on: ubuntu-latest

--- a/.github/workflows/holonix-update.yaml
+++ b/.github/workflows/holonix-update.yaml
@@ -23,11 +23,6 @@ on:
         type: boolean
         default: false
         required: true
-      update-launcher:
-        description: "Should Launcher be updated?"
-        type: boolean
-        default: false
-        required: true
   workflow_call:
     inputs:
       branch:
@@ -38,10 +33,6 @@ on:
         default: false
         required: false
       update-scaffolding:
-        type: boolean
-        default: false
-        required: false
-      update-launcher:
         type: boolean
         default: false
         required: false
@@ -70,10 +61,6 @@ jobs:
         if: ${{ inputs.update-scaffolding }}
         run: |
           nix flake update hc-scaffold
-      - name: Run the Launcher bump script
-        if: ${{ inputs.update-launcher }}
-        run: |
-          nix flake update hc-launch
       - name: Create pull request
         id: cpr
         uses: peter-evans/create-pull-request@v7
@@ -86,7 +73,6 @@ jobs:
 
             To apply more updates to this PR you can ask the bot to make changes. Try commenting with:
               - `@hra bump holochain`
-              - `@hra bump hc-launch`
               - `@hra bump hc-scaffold`
 
             You must be in the list of allowed users for this to work!

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ It may be that you want to add or remove packages included in the dev shell. If 
 packages = (with inputs'.holonix.packages; [
     holochain
 -   lair-keystore
--   hc-launch
 -   hc-scaffold
 -   hn-introspect
     rust # For Rust development, with the WASM target included for zome builds

--- a/flake.lock
+++ b/flake.lock
@@ -33,23 +33,6 @@
         "type": "github"
       }
     },
-    "hc-launch": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1764005928,
-        "narHash": "sha256-M1KiSMltyhLMsIageC3rCeVHnlzQU/8lwdGTNpf8Yhk=",
-        "owner": "holochain",
-        "repo": "hc-launch",
-        "rev": "b19fe6be4edff94043b7936496f5604bf7917e97",
-        "type": "github"
-      },
-      "original": {
-        "owner": "holochain",
-        "ref": "holochain-weekly",
-        "repo": "hc-launch",
-        "type": "github"
-      }
-    },
     "hc-scaffold": {
       "flake": false,
       "locked": {
@@ -170,7 +153,6 @@
       "inputs": {
         "crane": "crane",
         "flake-parts": "flake-parts",
-        "hc-launch": "hc-launch",
         "hc-scaffold": "hc-scaffold",
         "holochain": "holochain",
         "kitsune2": "kitsune2",

--- a/flake.lock
+++ b/flake.lock
@@ -36,16 +36,16 @@
     "hc-scaffold": {
       "flake": false,
       "locked": {
-        "lastModified": 1764011819,
-        "narHash": "sha256-dGFCjYlgvGiQQx0ubpYh2hf39+YjIirekeo/ZABe21Q=",
+        "lastModified": 1764163563,
+        "narHash": "sha256-KigJ3h25yNJfeQunPm5QYFPtLSk6nU3IEEvZY8w01Vo=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "2d71d47b9a2fec079671f3f385e01c238dee7f7e",
+        "rev": "87e997a7361d4aa7c1bb96261483ebba50223bd0",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.600.0",
+        "ref": "v0.600.1",
         "repo": "scaffolding",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
 
     # Holochain scaffolding CLI
     hc-scaffold = {
-      url = "github:holochain/scaffolding?ref=v0.600.0";
+      url = "github:holochain/scaffolding?ref=v0.600.1";
       flake = false;
     };
 

--- a/templates/custom-holochain/flake.nix
+++ b/templates/custom-holochain/flake.nix
@@ -37,7 +37,6 @@
             hcterm
             bootstrap-srv
             lair-keystore
-            hc-launch
             hc-scaffold
             hn-introspect
             hc-playground

--- a/templates/custom-rust/flake.nix
+++ b/templates/custom-rust/flake.nix
@@ -41,7 +41,6 @@
             hcterm
             bootstrap-srv
             lair-keystore
-            hc-launch
             hc-scaffold
             hn-introspect
             hc-playground

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -20,7 +20,6 @@
           hcterm
           bootstrap-srv
           lair-keystore
-          hc-launch
           hc-scaffold
           hn-introspect
           hc-playground


### PR DESCRIPTION
Do for `main` what #238 did for `holochain-0.6`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed hc-launch from development environment and build workflows across all configuration files and project templates
  * Updated hc-scaffold to version 0.600.1
  * Removed hc-launch from GitHub Actions build matrix and eliminated the dedicated automated version update job
  * Streamlined development environment setup and dependencies

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->