### PR TITLE
Maintenance

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,7 @@ jobs:
     needs: [nix-check, script-test]
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, macos-15-intel]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel]
         packages:
           - [holochain,hc,hcterm]
           - [bootstrap-srv]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,7 @@ jobs:
     needs: [nix-check, script-test]
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, macos-15-intel]
         packages:
           - [holochain,hc,hcterm]
           - [bootstrap-srv]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,13 +6,11 @@ on:
       - main
       - main-0.6
       - main-0.5
-      - main-0.4
   pull_request:
     branches:
       - main
       - main-0.6
       - main-0.5
-      - main-0.4
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -29,7 +27,7 @@ jobs:
       - name: Install nix
         uses: cachix/install-nix-action@v31
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.28.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.33.0/install
           extra_nix_config: |
             accept-flake-config = true
 
@@ -113,7 +111,7 @@ jobs:
       - name: Install nix
         uses: cachix/install-nix-action@v31
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.24.6/install
+          install_url: https://releases.nixos.org/nix/nix-2.33.0/install
           extra_nix_config: |
             accept-flake-config = true
 
@@ -152,7 +150,7 @@ jobs:
 
       - uses: cachix/install-nix-action@v31
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.28.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.33.0/install
           extra_nix_config: |
             accept-flake-config = true
 

--- a/.github/workflows/command-listener.yaml
+++ b/.github/workflows/command-listener.yaml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.28.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.33.0/install
           extra_nix_config: |
             accept-flake-config = true
       - name: set up git config
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.28.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.33.0/install
           extra_nix_config: |
             accept-flake-config = true
       - name: set up git config

--- a/.github/workflows/dispatch-listener.yaml
+++ b/.github/workflows/dispatch-listener.yaml
@@ -22,9 +22,3 @@ jobs:
     with:
       branch: main-0.5
       update-holochain: true
-  bump_holochain-0_4:
-    if: ${{ github.event.action == 'holochain-released' && startsWith(github.event.client_payload.tag, 'holochain-0.4') }}
-    uses: holochain/holonix/.github/workflows/holonix-update.yaml@main
-    with:
-      branch: main-0.4
-      update-holochain: true

--- a/.github/workflows/holonix-cache-trigger.yaml
+++ b/.github/workflows/holonix-cache-trigger.yaml
@@ -23,7 +23,3 @@ jobs:
     uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main
     with:
       branch: main-0.5
-  update-cache-main-0_4:
-    uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main
-    with:
-      branch: main-0.4

--- a/.github/workflows/holonix-cache.yaml
+++ b/.github/workflows/holonix-cache.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-26, macos-15-intel ]
+        os: [ ubuntu-latest, macos-latest, macos-15-intel ]
 
     runs-on: ${{ matrix.os }}
 
@@ -101,7 +101,7 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: x86_64-linux
-          - os: macos-26
+          - os: macos-latest
             platform: aarch64-darwin
           - os: macos-15-intel
             platform: x86_64-darwin

--- a/.github/workflows/holonix-cache.yaml
+++ b/.github/workflows/holonix-cache.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, macos-15-intel ]
+        os: [ ubuntu-latest, macos-26, macos-15-intel ]
 
     runs-on: ${{ matrix.os }}
 
@@ -98,15 +98,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, macos-15-intel ]
         include:
           - os: ubuntu-latest
             platform: x86_64-linux
-          - os: macos-latest
+          - os: macos-26
             platform: aarch64-darwin
           - os: macos-15-intel
             platform: x86_64-darwin
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: cachix/install-nix-action@v31
         with:
@@ -118,8 +117,8 @@ jobs:
           name: holochain-ci
       - name: Check the Holonix cache
         uses: holochain/nix-cache-check@v1
-        # env:
-        #  NIX_CONFIG: "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+        env:
+          NIX_CONFIG: "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
         with:
           # The default shell in the Holonix flake
           derivation: "github:holochain/holonix?ref=${{ needs.cache-update.outputs.branch }}#devShells.${{ matrix.platform }}.default"

--- a/.github/workflows/holonix-cache.yaml
+++ b/.github/workflows/holonix-cache.yaml
@@ -8,7 +8,6 @@ on:
       - main
       - main-0.6
       - main-0.5
-      - main-0.4
   workflow_call:
     inputs:
       branch:
@@ -26,7 +25,6 @@ on:
           - main
           - main-0.6
           - main-0.5
-          - main-0.4
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.branch }}-${{ github.ref_name }}
@@ -45,7 +43,7 @@ jobs:
     steps:
       - uses: cachix/install-nix-action@v31
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.28.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.33.0/install
           extra_nix_config: |
             accept-flake-config = true
       - uses: cachix/cachix-action@v16
@@ -89,12 +87,9 @@ jobs:
           CACHIX_AUTH_TOKEN: "${{ secrets.CACHIX_AUTH_TOKEN }}"
         run: |
           # See https://docs.cachix.org/pushing#id1
-          nix develop --build -L --profile result-develop "github:holochain/holonix?ref=${{ steps.select_branch.outputs.branch }}"
+          nix develop --profile result-develop -c true "github:holochain/holonix?ref=${{ steps.select_branch.outputs.branch }}"
 
-          # Push both results to the cache
-          for i in result-*; do
-            cachix push holochain-ci $i
-          done
+          cachix push holochain-ci result-develop
     outputs:
       branch: ${{ steps.select_branch.outputs.branch }}
 
@@ -116,7 +111,7 @@ jobs:
     steps:
       - uses: cachix/install-nix-action@v31
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.28.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.33.0/install
           extra_nix_config: |
             accept-flake-config = true
       - uses: cachix/cachix-action@v16

--- a/.github/workflows/holonix-cache.yaml
+++ b/.github/workflows/holonix-cache.yaml
@@ -87,8 +87,7 @@ jobs:
           CACHIX_AUTH_TOKEN: "${{ secrets.CACHIX_AUTH_TOKEN }}"
         run: |
           # See https://docs.cachix.org/pushing#id1
-          nix develop --profile result-develop -c true "github:holochain/holonix?ref=${{ steps.select_branch.outputs.branch }}"
-
+          nix develop --profile result-develop "github:holochain/holonix?ref=${{ steps.select_branch.outputs.branch }}" -c true
           cachix push holochain-ci result-develop
     outputs:
       branch: ${{ steps.select_branch.outputs.branch }}

--- a/.github/workflows/holonix-update.yaml
+++ b/.github/workflows/holonix-update.yaml
@@ -12,7 +12,6 @@ on:
           - main
           - main-0.6
           - main-0.5
-          - main-0.4
       update-holochain:
         description: "Should Holochain be updated?"
         type: boolean
@@ -49,7 +48,7 @@ jobs:
           ref: ${{ inputs.branch }}
       - uses: cachix/install-nix-action@v31
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.28.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.33.0/install
           extra_nix_config: |
             accept-flake-config = true
       - name: Run the Holochain and Lair bump scripts

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 `main` [![Holonix cache](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml/badge.svg)](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml)
 `main-0.6` [![Holonix cache](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml/badge.svg?branch=main-0.6)](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml)
 `main-0.5` [![Holonix cache](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml/badge.svg?branch=main-0.5)](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml)
-`main-0.4` [![Holonix cache](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml/badge.svg?branch=main-0.4)](https://github.com/holochain/holonix/actions/workflows/holonix-cache.yaml)
 
 # Holonix
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1763511871,
-        "narHash": "sha256-KKZWi+ij7oT0Ag8yC6MQkzfHGcytyjMJDD+47ZV1YNU=",
+        "lastModified": 1766194365,
+        "narHash": "sha256-4AFsUZ0kl6MXSm4BaQgItD0VGlEKR3iq7gIaL7TjBvc=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "099f9014bc8d0cd6e445470ea1df0fd691d5a548",
+        "rev": "7d8ec2c71771937ab99790b45e6d9b93d15d9379",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1762980239,
-        "narHash": "sha256-8oNVE8TrD19ulHinjaqONf9QWCKK+w4url56cdStMpM=",
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "52a2caecc898d0b46b2b905f058ccc5081f842da",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
         "type": "github"
       },
       "original": {
@@ -103,27 +103,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763622513,
-        "narHash": "sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB+19M=",
+        "lastModified": 1766201043,
+        "narHash": "sha256-eplAP+rorKKd0gNjV3rA6+0WMzb1X1i16F5m5pASnjA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c58bc7f5459328e4afac201c5c4feb7c818d604b",
+        "rev": "b3aad468604d3e488d627c0b43984eb60e75e782",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1761765539,
-        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763692705,
-        "narHash": "sha256-tCKCyMYU0Vy+ph/xswlNsYXXjnFVweWBV+ew/5FS9tA=",
+        "lastModified": 1766371695,
+        "narHash": "sha256-W7CX9vy7H2Jj3E8NI4djHyF8iHSxKpb2c/7uNQ/vGFU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6fbf5d328dce1828d887b8ee7d44a785196a34e7",
+        "rev": "d81285ba8199b00dc31847258cae3c655b605e8c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
 
   # specify all input dependencies needed to create the outputs of the flake
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.11";
 
     # utility to iterate over multiple target platforms
     flake-parts.url = "github:hercules-ci/flake-parts";


### PR DESCRIPTION
- Upgrade Nix to latest
- Update to currently recommended caching pattern for Cachix
- Remove support for 0.4
- Update to nixpkgs 25.11

Closes https://github.com/holochain/holonix/issues/248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Nix installer to 2.33.0 across CI workflows.
  * Removed an older branch variant from CI triggers, cache updates and workflow inputs.
  * Simplified cache/update workflow and consolidated cache push logic for faster CI.
  * Updated NixOS package input to a newer release.
* **Documentation**
  * Removed the legacy Holonix cache badge from the README.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->