### PR TITLE
Update the kitsune2-bootstrap-srv binary to enable the Iroh relay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,16 +70,16 @@
     "kitsune2": {
       "flake": false,
       "locked": {
-        "lastModified": 1763403287,
-        "narHash": "sha256-dqQJMoDbcD0ekttrv5+8ph5Yf25EdXwKktsxNjV57Iw=",
+        "lastModified": 1770115587,
+        "narHash": "sha256-bF/7ERAfd41zEfzoUBKKyxuQU3c0QUi2Fc8MpM+hnEs=",
         "owner": "holochain",
         "repo": "kitsune2",
-        "rev": "22de6e42100aa960d05f5f30427a236ad922bd80",
+        "rev": "31b84100151a1eccaf7ed3e0037d27f77b5d7cdb",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.3.2",
+        "ref": "main",
         "repo": "kitsune2",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
     };
 
     kitsune2 = {
-      url = "github:holochain/kitsune2?ref=v0.3.2";
+      url = "github:holochain/kitsune2?ref=main";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -82,15 +82,10 @@
             bootstrap-srv =
               craneLib.buildPackage {
                 pname = "kitsune2-bootstrap-srv";
-                # only build kitsune2-bootstrap-srv binary
-                cargoExtraArgs = "-p kitsune2_bootstrap_srv";
+                # only build kitsune2-bootstrap-srv binary with SBD (default) disabled and the Iroh relay enabled
+                cargoExtraArgs = "-p kitsune2_bootstrap_srv --no-default-features --features=iroh-relay";
                 # Use Kitsune2 sources as defined in input dependencies.
                 src = craneLib.cleanCargoSource inputs.kitsune2;
-                # additional packages needed for build
-                nativeBuildInputs = [ pkgs.perl pkgs.cmake ];
-                buildInputs = [
-                  pkgs.openssl
-                ];
                 # do not check built package as it either builds successfully or not
                 doCheck = false;
               };


### PR DESCRIPTION
This updates the kitsune2-bootstrap-srv binary package to `v0.4.0-dev.2`, disables the default SBD feature, and enables the Iroh relay feature.

Closes #252.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependency source to latest development version
  * Optimized bootstrap server build configuration with refined feature flags
  * Streamlined build inputs for improved efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->