### PR TITLE
chore: rm playground

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,23 +132,6 @@
         "type": "github"
       }
     },
-    "playground": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1756729856,
-        "narHash": "sha256-xJnIfcIyLRTXsf+N8OOMnqzRkx2gT/DSta7qCm8yU7Y=",
-        "owner": "darksoil-studio",
-        "repo": "holochain-playground",
-        "rev": "5e858641de8ac6113cfa6b47ea1350762a629a61",
-        "type": "github"
-      },
-      "original": {
-        "owner": "darksoil-studio",
-        "ref": "main",
-        "repo": "holochain-playground",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "crane": "crane",
@@ -158,7 +141,6 @@
         "kitsune2": "kitsune2",
         "lair-keystore": "lair-keystore",
         "nixpkgs": "nixpkgs",
-        "playground": "playground",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/templates/custom-holochain/flake.nix
+++ b/templates/custom-holochain/flake.nix
@@ -39,7 +39,6 @@
             lair-keystore
             hc-scaffold
             hn-introspect
-            hc-playground
             rust # For Rust development, with the WASM target included for zome builds
           ]) ++ (with pkgs; [
             nodejs_20 # For UI development

--- a/templates/custom-rust/flake.nix
+++ b/templates/custom-rust/flake.nix
@@ -43,7 +43,6 @@
             lair-keystore
             hc-scaffold
             hn-introspect
-            hc-playground
           ]) ++ (with pkgs; [
             nodejs_20 # For UI development
             binaryen # For WASM optimisation

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -22,7 +22,6 @@
           lair-keystore
           hc-scaffold
           hn-introspect
-          hc-playground
           rust # For Rust development, with the WASM target included for zome builds
         ]) ++ (with pkgs; [
           nodejs_20 # For UI development


### PR DESCRIPTION
Playground was removed in `main-0.6`, but not `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Holochain Playground integration from development environment configuration across the main project and all templates, streamlining the available development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->