### PR TITLE
ci: use hra2 github token from hc-github-config

### DIFF
--- a/.github/workflows/command-listener.yaml
+++ b/.github/workflows/command-listener.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Flake update
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
-          GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
         run: |
           gh pr checkout $PR_NUMBER --repo holochain/holonix
           ./scripts/bump-holochain.sh
@@ -84,7 +84,7 @@ jobs:
       - name: Flake update
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
-          GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
         run: |
           gh pr checkout $PR_NUMBER --repo holochain/holonix
           nix flake update hc-scaffold

--- a/.github/workflows/dispatch-listener.yaml
+++ b/.github/workflows/dispatch-listener.yaml
@@ -11,7 +11,7 @@ jobs:
       branch: main
       update-holochain: true
     secrets:
-      HRA_GITHUB_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
+      HRA2_GITHUB_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
   bump_holochain-main-0_6:
     if: ${{ github.event.action == 'holochain-released' && startsWith(github.event.client_payload.tag, 'holochain-0.6') }}
     uses: holochain/holonix/.github/workflows/holonix-update.yaml@main
@@ -19,7 +19,7 @@ jobs:
       branch: main-0.6
       update-holochain: true
     secrets:
-      HRA_GITHUB_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
+      HRA2_GITHUB_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
   bump_holochain-main-0_5:
     if: ${{ github.event.action == 'holochain-released' && startsWith(github.event.client_payload.tag, 'holochain-0.5') }}
     uses: holochain/holonix/.github/workflows/holonix-update.yaml@main
@@ -27,4 +27,4 @@ jobs:
       branch: main-0.5
       update-holochain: true
     secrets:
-      HRA_GITHUB_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
+      HRA2_GITHUB_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}

--- a/.github/workflows/holonix-update.yaml
+++ b/.github/workflows/holonix-update.yaml
@@ -36,7 +36,7 @@ on:
         default: false
         required: false
     secrets:
-      HRA_GITHUB_TOKEN:
+      HRA2_GITHUB_TOKEN:
         required: true
 
 concurrency:
@@ -67,7 +67,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.HRA_GITHUB_TOKEN }}
+          token: ${{ secrets.HRA2_GITHUB_TOKEN }}
           committer: "Holochain Release Automation <hra+gh@holochain.org>"
           title: "Update Holonix versions on ${{ inputs.branch }}"
           body: |
@@ -86,5 +86,5 @@ jobs:
       - name: Enable auto-merge
         if: steps.cpr.outputs.pull-request-operation == 'created' && github.event_name == 'workflow_dispatch'
         env:
-          GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
         run: gh pr merge --rebase --auto "${{ steps.cpr.outputs.pull-request-number }}"


### PR DESCRIPTION
This has been provided via `hc-github-config`. The existing `HRA_GITHUB_TOKEN` has expired and can be removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow configurations to reference a new authentication secret across multiple CI/CD automation jobs. No functional or user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->