### PR TITLE
fix: bootstrap server not building

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,16 +53,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1775133797,
-        "narHash": "sha256-pPsH/g8mos+gA8Xwr8/NYkFsbaiXC7MTYrejooJhRuk=",
+        "lastModified": 1775246441,
+        "narHash": "sha256-bqK/RGhsBlsNhajeZguNTYsXuTIjPwNiD/y6/CkvZHA=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "847773ecc5efd4f34995338cec8bbd6e39cf967a",
+        "rev": "be3d67ec50743ffc752e791fe792538b75a26a83",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.6.1-rc.5",
+        "ref": "holochain-0.6.1-rc.6",
         "repo": "holochain",
         "type": "github"
       }
@@ -70,16 +70,16 @@
     "kitsune2": {
       "flake": false,
       "locked": {
-        "lastModified": 1775089835,
-        "narHash": "sha256-JpY+mW/YG4iHCFJg0AgMXOri1Wu/yjazqbs8C2Zu3fw=",
+        "lastModified": 1775238017,
+        "narHash": "sha256-x/sMd6d0T5Fxx8W5EbpmmRLa6YVrzJccImjp2rERkXU=",
         "owner": "holochain",
         "repo": "kitsune2",
-        "rev": "5a291f0e4768dd7236bb0f818714015313316137",
+        "rev": "ea974667bffcc1952f34c575fec569093d9581ca",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.4.0-dev.7",
+        "ref": "v0.4.0-dev.9",
         "repo": "kitsune2",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
               craneLib.buildPackage {
                 pname = "kitsune2-bootstrap-srv";
                 # only build kitsune2-bootstrap-srv binary
-                cargoExtraArgs = "-p kitsune2_bootstrap_srv --no-default-features --features iroh-relay";
+                cargoExtraArgs = "-p kitsune2_bootstrap_srv";
                 # Use Kitsune2 sources as defined in input dependencies.
                 src = craneLib.cleanCargoSource inputs.kitsune2;
                 # additional packages needed for build


### PR DESCRIPTION
This leaves the bootstrap server only working as a bootstrap server but `nix develop` will work... Not great but a slight improvement over where we are right now