### PR TITLE
ci: Pass CACHIX_AUTH_TOKEN to holonix-cache reusable workflow

### DIFF
--- a/.github/workflows/holonix-cache-trigger.yaml
+++ b/.github/workflows/holonix-cache-trigger.yaml
@@ -15,11 +15,17 @@ jobs:
     uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main
     with:
       branch: main
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
   update-cache-main-0_6:
     uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main
     with:
       branch: main-0.6
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
   update-cache-main-0_5:
     uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main
     with:
       branch: main-0.5
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/holonix-cache.yaml
+++ b/.github/workflows/holonix-cache.yaml
@@ -13,6 +13,9 @@ on:
       branch:
         required: true
         type: string
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
   # Allow the cache update to be run manually.
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

- The cache trigger workflow calls `holonix-cache.yaml` as a reusable workflow but never forwarded `CACHIX_AUTH_TOKEN`. GitHub Actions does not auto-inherit secrets in reusable-workflow calls, so the cachix push step received an empty token and the API returned `401 Unauthorized` whenever there was something to upload.
- Failures only surfaced when a branch produced a new store path. Days where every branch was already cached short-circuited with `Nothing to push` and silently passed, which masked the breakage from January onward.
- Declare the secret on `workflow_call` in `holonix-cache.yaml` and forward it from each job in `holonix-cache-trigger.yaml`, mirroring the named-block pattern used in `dispatch-listener.yaml` for `HRA2_GITHUB_TOKEN`.

## Verification

- Manual `workflow_dispatch` on `holonix-cache.yaml` directly succeeds (e.g. run [25529042780](https://github.com/holochain/holonix/actions/runs/25529042780)) because the secret is in scope when the workflow is the entry point.
- Same workflow invoked via `holonix-cache-trigger.yaml` fails with 401 on push (e.g. run [25528512559](https://github.com/holochain/holonix/actions/runs/25528512559)) — only the reusable-call path loses the secret.

## Test plan

- [ ] After merge, trigger `Holonix cache trigger` via `workflow_dispatch` and confirm all three branches (`main`, `main-0.6`, `main-0.5`) push to cachix successfully on every matrix entry that has new paths to upload.