### PR TITLE
ci: request team review on Holonix update

### DIFF
--- a/.github/workflows/holonix-update.yaml
+++ b/.github/workflows/holonix-update.yaml
@@ -83,6 +83,7 @@ jobs:
           commit-message: "chore: Update Holonix versions"
           draft: false
           delete-branch: true
+          team-reviewers: holochain-devs
       - name: Enable auto-merge
         if: steps.cpr.outputs.pull-request-operation == 'created' && github.event_name == 'workflow_dispatch'
         env:


### PR DESCRIPTION
Same logic as https://github.com/holochain/binaries/blob/main/.github/workflows/auto-bump.yaml#L90

I want Holonix bumps to get posted in our PR channel