### PR TITLE
[backport] ci: use HRA2 github token from hc-github-config for release PRs

### DIFF
--- a/.github/workflows/command-listener.yaml
+++ b/.github/workflows/command-listener.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Flake update
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
-          GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
         run: |
           gh pr checkout $PR_NUMBER --repo holochain/holonix
           ./scripts/bump-holochain.sh
@@ -84,7 +84,7 @@ jobs:
       - name: Flake update
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
-          GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
         run: |
           gh pr checkout $PR_NUMBER --repo holochain/holonix
           nix flake update hc-scaffold

--- a/.github/workflows/dispatch-listener.yaml
+++ b/.github/workflows/dispatch-listener.yaml
@@ -10,15 +10,21 @@ jobs:
     with:
       branch: main
       update-holochain: true
+    secrets:
+      HRA2_GITHUB_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
   bump_holochain-main-0_6:
     if: ${{ github.event.action == 'holochain-released' && startsWith(github.event.client_payload.tag, 'holochain-0.6') }}
     uses: holochain/holonix/.github/workflows/holonix-update.yaml@main
     with:
       branch: main-0.6
       update-holochain: true
+    secrets:
+      HRA2_GITHUB_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
   bump_holochain-main-0_5:
     if: ${{ github.event.action == 'holochain-released' && startsWith(github.event.client_payload.tag, 'holochain-0.5') }}
     uses: holochain/holonix/.github/workflows/holonix-update.yaml@main
     with:
       branch: main-0.5
       update-holochain: true
+    secrets:
+      HRA2_GITHUB_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}

--- a/.github/workflows/dispatch-listener.yaml
+++ b/.github/workflows/dispatch-listener.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   bump_holochain-main:
     if: ${{ github.event.action == 'holochain-released' && startsWith(github.event.client_payload.tag, 'holochain-0.7') }}
-    uses: holochain/holonix/.github/workflows/holonix-update.yaml@main
+    uses: holochain/holonix/.github/workflows/holonix-update.yaml@main-0.6
     with:
       branch: main
       update-holochain: true
@@ -14,7 +14,7 @@ jobs:
       HRA2_GITHUB_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
   bump_holochain-main-0_6:
     if: ${{ github.event.action == 'holochain-released' && startsWith(github.event.client_payload.tag, 'holochain-0.6') }}
-    uses: holochain/holonix/.github/workflows/holonix-update.yaml@main
+    uses: holochain/holonix/.github/workflows/holonix-update.yaml@main-0.6
     with:
       branch: main-0.6
       update-holochain: true
@@ -22,7 +22,7 @@ jobs:
       HRA2_GITHUB_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
   bump_holochain-main-0_5:
     if: ${{ github.event.action == 'holochain-released' && startsWith(github.event.client_payload.tag, 'holochain-0.5') }}
-    uses: holochain/holonix/.github/workflows/holonix-update.yaml@main
+    uses: holochain/holonix/.github/workflows/holonix-update.yaml@main-0.6
     with:
       branch: main-0.5
       update-holochain: true

--- a/.github/workflows/holonix-cache-trigger.yaml
+++ b/.github/workflows/holonix-cache-trigger.yaml
@@ -12,14 +12,14 @@ on:
 
 jobs:
   update-cache-main:
-    uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main
+    uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main-0.6
     with:
       branch: main
   update-cache-main-0_6:
-    uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main
+    uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main-0.6
     with:
       branch: main-0.6
   update-cache-main-0_5:
-    uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main
+    uses: holochain/holonix/.github/workflows/holonix-cache.yaml@main-0.6
     with:
       branch: main-0.5

--- a/.github/workflows/holonix-update.yaml
+++ b/.github/workflows/holonix-update.yaml
@@ -35,6 +35,9 @@ on:
         type: boolean
         default: false
         required: false
+    secrets:
+      HRA2_GITHUB_TOKEN:
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.branch }}
@@ -64,7 +67,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          branch-token: ${{ secrets.HRA_GITHUB_TOKEN }}
+          token: ${{ secrets.HRA2_GITHUB_TOKEN }}
           committer: "Holochain Release Automation <hra+gh@holochain.org>"
           title: "Update Holonix versions on ${{ inputs.branch }}"
           body: |
@@ -83,5 +86,5 @@ jobs:
       - name: Enable auto-merge
         if: steps.cpr.outputs.pull-request-operation == 'created' && github.event_name == 'workflow_dispatch'
         env:
-          GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
         run: gh pr merge --rebase --auto "${{ steps.cpr.outputs.pull-request-number }}"


### PR DESCRIPTION
This backports PR #258 to the `main-0.6` maintanence branch.

Also cherry-picked and fixup-squashed some previous commits from `main` that were precursors to that PR.

Also, also, changed the calls to the reusable workflows in this branch to use this branch i.e. `@main-0.6` instead of `@main`. I think this is what it should be.